### PR TITLE
fix/non including test title

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "playwright-testrail-reporter",
+  "name": "@bun913/playwright-testrail-reporter",
   "version": "0.9.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "playwright-testrail-reporter",
-      "version": "0.9.0",
+      "name": "@bun913/playwright-testrail-reporter",
+      "version": "0.9.9",
       "dependencies": {
         "@playwright/test": "^1.51.1",
         "axios": "^1.8.3"

--- a/src/helpers/caseExtractor.ts
+++ b/src/helpers/caseExtractor.ts
@@ -1,4 +1,3 @@
-
 /**
  * Extract TestRail case ID from test title.
  *
@@ -27,9 +26,7 @@ export function extractCaseId(title: string): number | null {
  * @param title The test title
  * @returns The case ID as a number, or null if not found
  */
-export function extractCaseIdFromTest(
-	title: string,
-): number | null {
+export function extractCaseIdFromTest(title: string): number | null {
 	// Extract from test title only
 	// Tests without TestRail IDs should be skipped
 	return extractCaseId(title);

--- a/src/helpers/caseExtractor.ts
+++ b/src/helpers/caseExtractor.ts
@@ -1,5 +1,3 @@
-import path from "path";
-import type { TestCase } from "@playwright/test/reporter";
 
 /**
  * Extract TestRail case ID from test title.
@@ -24,41 +22,15 @@ export function extractCaseId(title: string): number | null {
 
 /**
  * Extract case ID from a Playwright test.
- * Attempts to find ID in test title first, then fallbacks to file path.
+ * Only extracts from test title - tests without IDs are skipped.
  *
- * @param testInfo The Playwright test case or test title
- * @param filePath Optional file path (used when testInfo is just a title string)
+ * @param title The test title
  * @returns The case ID as a number, or null if not found
  */
 export function extractCaseIdFromTest(
-	testInfo: TestCase | string,
-	filePath?: string,
+	title: string,
 ): number | null {
-	// Handle when testInfo is a TestCase object
-	if (typeof testInfo !== "string") {
-		// Try to extract from test title first
-		const idFromTitle = extractCaseId(testInfo.title);
-		if (idFromTitle) {
-			return idFromTitle;
-		}
-
-		// Use the file path from the TestCase object
-		filePath = testInfo.location?.file;
-	} else {
-		// When testInfo is a string (title), extract from it
-		const idFromTitle = extractCaseId(testInfo);
-		if (idFromTitle) {
-			return idFromTitle;
-		}
-	}
-
-	// If no file path available, can't extract from file
-	if (!filePath) {
-		return null;
-	}
-
-	// Try to extract from file path as fallback
-	const fileName = path.basename(filePath, path.extname(filePath));
-	const match = fileName.match(/C(\d+)/);
-	return match ? parseInt(match[1], 10) : null;
+	// Extract from test title only
+	// Tests without TestRail IDs should be skipped
+	return extractCaseId(title);
 }

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -33,7 +33,7 @@ export default class TestRailReporter implements Reporter {
 	 * Playwright invokes this after each test completes (pass, fail, or skip)
 	 */
 	onTestEnd(test: TestCase, result: TestResult): void {
-		const caseId = extractCaseIdFromTest(test.title, test.location.file);
+		const caseId = extractCaseIdFromTest(test.title);
 		if (!caseId) return;
 
 		this.pendingCases++;

--- a/tests/helpers/caseExtractor.spec.ts
+++ b/tests/helpers/caseExtractor.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { extractCaseId } from "../../src/helpers/caseExtractor";
+import { extractCaseId, extractCaseIdFromTest } from "../../src/helpers/caseExtractor";
 
 describe("caseExtractor", () => {
   describe("extractCaseId", () => {
@@ -28,6 +28,28 @@ describe("caseExtractor", () => {
 
     it("should return null for empty string", () => {
       expect(extractCaseId("")).toBeNull();
+    });
+  });
+
+  describe("extractCaseIdFromTest", () => {
+    it("should extract case ID from test title with C format", () => {
+      const result = extractCaseIdFromTest("C11111 delete a user with tenant");
+      expect(result).toBe(11111);
+    });
+
+    it("should extract case ID from test title with [C] format", () => {
+      const result = extractCaseIdFromTest("[C99999] create a user");
+      expect(result).toBe(99999);
+    });
+
+    it("should return null for test title without case ID", () => {
+      const result = extractCaseIdFromTest("create a user without special settings");
+      expect(result).toBeNull();
+    });
+
+    it("should return null for test title with case ID not at beginning", () => {
+      const result = extractCaseIdFromTest("deletes a user with tenant C12345");
+      expect(result).toBeNull();
     });
   });
 }); 


### PR DESCRIPTION
## Background

When users use a title without TestRail case id like:

- it("create a new user")
  - This is OK: `it("C11111 create a new user")`

The reporter fails.

So, I fixed it by skipping when the test case id wasn't found.

